### PR TITLE
Pass Chat client properties object to native module

### DIFF
--- a/lib/Client.js
+++ b/lib/Client.js
@@ -18,7 +18,7 @@ const {
 } = NativeModules;
 
 class Client {
-  constructor(initialToken, synchronizationStrategy, initialMessageCount) {
+  constructor(initialToken, props) {
     // properties
     this.initialToken = initialToken;
     this.user = {};
@@ -50,7 +50,8 @@ class Client {
 
     this.onClientSynchronized = null;
     this._properties = {
-      initialMessageCount: initialMessageCount ? initialMessageCount : 100,
+      initialMessageCount: props.initialMessageCount || 100,
+      ...props,
     };
 
     // event handlers


### PR DESCRIPTION
Pass Chat client properties object to native module so it is possible to set other attributes like region.